### PR TITLE
ci: adopt golangci-lint v2.12.1 and exclude goconst from tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
+          version: v2.12.1
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
           - errcheck
           - dupl
           - gosec
+          - goconst
           - paralleltest
         path: (.+)_test\.go
       - linters:


### PR DESCRIPTION
## Summary
- Pin `golangci-lint` to **v2.12.1** in `.github/workflows/lint.yml`. The action was unpinned and auto-installing the latest binary, which could break `main` when v2.12.1 shipped with stricter `goconst` defaults.
- Exclude `goconst` from `(.+)_test\.go` in `.golangci.yml`. Test fixtures legitimately repeat literals like `"Hello, World!"` and `"test-agent"`; forcing constants there adds noise without value, and matches the existing test-file exclusions for `lll`, `gocyclo`, `errcheck`, `dupl`, `gosec`, `paralleltest`.

No production-code `goconst` findings in this repo, so unlike the yardstick equivalent (StacklokLabs/yardstick#101) no constants needed extracting from `cmd/`.

Verified locally with `golangci-lint v2.12.1`: `0 issues.`

## Test plan
- [ ] Linting workflow passes on this PR
- [ ] Action logs show `Installing golangci-lint binary v2.12.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)