### PR TITLE
chore: update Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackloklabs/gofetch
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.1


### PR DESCRIPTION
## Summary

Updates the project to the latest stable Go release, **1.26.4** (was 1.25.7).

- Bumps the `go` directive in `go.mod`.
- CI workflows (`release.yml`, `lint.yml`, `test.yml`, `build.yml`) all use `go-version-file: 'go.mod'`, so they pick up the new version automatically — no other files needed changing.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` — all packages pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)