### PR TITLE
chore: drop patch version from go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackloklabs/gofetch
 
-go 1.26.4
+go 1.26
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.1


### PR DESCRIPTION
## Summary

Changes the `go` directive in `go.mod` from `1.26.4` to `1.26`.

The `go` directive only needs the minor version — pinning the patch (`.4`) forces that exact toolchain, whereas `go 1.26` lets the build use any available 1.26.x patch. CI selects a concrete patch toolchain automatically.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)